### PR TITLE
feature: add get link endpoint

### DIFF
--- a/ocean-dbs/oceandbs/tests/test_quote_link_endpoint.py
+++ b/ocean-dbs/oceandbs/tests/test_quote_link_endpoint.py
@@ -1,0 +1,36 @@
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, APIClient, APITestCase, RequestsClient
+import responses
+
+# Create your tests here.
+# Using the standard RequestFactory API to create a form POST request
+class TestLinkEndpoint(APITestCase):
+  fixtures = ["storages.json"]
+
+  def setUp(self):
+    self.factory = APIRequestFactory()
+    self.client = APIClient()
+  
+  @responses.activate
+  def test_get_link_endpoint(self):
+    responses.get(
+      url= 'https://filecoin.org/quote/123565/link?nonce=1&signature=0xXXXXX',
+      json=[
+        {
+          "type": "filecoin",
+          "CID": "xxxx",
+        }
+      ],
+      status=200
+    )
+
+    response = self.client.get('/quote/123565/link?nonce=1&signature=0xXXXXX')
+    
+    # Assert proper HTTP status code
+    self.assertEqual(response.status_code, status.HTTP_200_OK)
+    # Assert content of the response itself, pure JSON
+    self.assertEqual(len(response.data), 2)
+    self.assertIsNotNone(response.data['type'])
+    self.assertEqual(response.data['type'], 'filecoin')
+    self.assertIsNotNone(response.data['CID'])
+    self.assertEqual(response.data['CID'], 'xxxx')

--- a/ocean-dbs/oceandbs/tests/tests_post_quotes.py
+++ b/ocean-dbs/oceandbs/tests/tests_post_quotes.py
@@ -12,20 +12,6 @@ class TestGetQuoteEndpoint(APITestCase):
     self.factory = APIRequestFactory()
     self.client = APIClient()
 
-  def test_get_quotes_endpoint(self):
-    response = self.client.get('/quotes/')
-
-    # Assert proper HTTP status code
-    self.assertEqual(response.status_code, 200)
-
-    # Assert content of the response itself, pure JSON
-    self.assertEqual(len(response.data), 1)
-
-    # Assert content of the response itself, pure JSON
-    self.assertEqual(response.data[0]['duration'], 2380293823)
-    self.assertEqual(response.data[0]['tokenAddress'], '0xOCEAN_on_MAINNET')
-    self.assertEqual(response.data[0]['approveAddress'], '0x123')
-
   @responses.activate
   def test_quote_creation(self):
     body = {

--- a/ocean-dbs/oceandbs/urls.py
+++ b/ocean-dbs/oceandbs/urls.py
@@ -4,6 +4,7 @@ from . import views
 urlpatterns = [
     path('storages/', views.StorageList.as_view(), name="info"),
     path('quote/<int:quoteId>/', views.QuoteStatus.as_view(), name="status"),
+    path('quote/<int:quoteId>/link', views.QuoteLink.as_view(), name="link"),
     path('quotes/', views.QuoteList.as_view()),
     path('upload/', views.UploadFile.as_view())
 ]


### PR DESCRIPTION
Fixes https://github.com/oceanprotocol/decentralized_storage_backend/issues/12 .

Changes proposed in this PR:

    Adding a link endpoint returning the CID of a file already using a given storage service, following 

    Get link endpoint #12 .

See the remaining question there.